### PR TITLE
missing include and linkopts

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -16,7 +16,7 @@ cc_binary(
     name = "send_hello",
     srcs = ["e02_send_hello.c"],
     copts = ["-DLOGGER_ENABLE"],
-    linkopts = ["-pthread"],
+    linkopts = ["-pthread", "-lm"],
     deps = [
         "//iota_client_service:config",
         "//iota_client_service:service",
@@ -68,7 +68,7 @@ cc_binary(
     name = "send_tokens",
     srcs = ["e06_send_tokens.c"],
     copts = ["-DLOGGER_ENABLE"],
-    linkopts = ["-pthread"],
+    linkopts = ["-pthread", "-lm"],
     deps = [
         "//iota_client_service:config",
         "//iota_client_service:service",

--- a/examples/e04_generate_address.c
+++ b/examples/e04_generate_address.c
@@ -5,6 +5,8 @@
 #include "utils/time.h"
 #include <inttypes.h>
 
+#include "iota_client_service/config.h"
+
 static tryte_t const *const SEED =
         (tryte_t *)"G9JEMIRJKUXDKUPPAIMEQSGVADYLSJRSBTEIRDWSCTLCVQOJWBM9XESTWTSONOTDDQUXMYCNVAKZWPPYW";
 


### PR DESCRIPTION
commit 85f7e86f955d44dad85a8b6e5d1f58e4fc3b9d57:

When porting to BitBake, I got the following error for both `send_hello` and `send_tokens` targets:
```
| Execution platform: @bazel_tools//platforms:host_platform
| /home/bernardo/dev/yocto/poky/build/tmp/work/armv7vet2hf-neon-poky-linux-gnueabi/c-iota-workshop/git-r0/bazel/output_base/external/yocto_compiler/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/../../libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/8.3.0/ld: bazel-out/armeabi-opt/bin/external/entangled/cclient/api/libapi_extended.a(prepare_transfers.o): undefined reference to symbol 'trunc@@GLIBC_2.4'
| /home/bernardo/dev/yocto/poky/build/tmp/work/armv7vet2hf-neon-poky-linux-gnueabi/c-iota-workshop/git-r0/bazel/output_base/external/yocto_compiler/recipe-sysroot-native/usr/bin/arm-poky-linux-gnueabi/../../libexec/arm-poky-linux-gnueabi/gcc/arm-poky-linux-gnueabi/8.3.0/ld: /home/bernardo/dev/yocto/poky/build/tmp/work/armv7vet2hf-neon-poky-linux-gnueabi/c-iota-workshop/git-r0/bazel/output_base/external/yocto_compiler/recipe-sysroot/lib/libm.so.6: error adding symbols: DSO missing from command line
```

I previously had a similar problem when porting cIRI.
Adding `-lm` to `linkopts` to Bazel target definitions solved the issue.

---
commit ff5b8e7d2e3a31163b482e22d8c36b100c810c37:

Example 4 was missing the include to `iota_client_service/config.h`, which generated the following error:

```
| Execution platform: @bazel_tools//platforms:host_platform
| <command-line>: warning: "_FORTIFY_SOURCE" redefined
| <command-line>: note: this is the location of the previous definition
| examples/e04_generate_address.c: In function 'get_new_address':
| examples/e04_generate_address.c:18:38: error: 'SECURITY_LEVEL' undeclared (first use in this function); did you mean 'SECURITY_LEVEL_MAX'?
|      address_opt_t opt = {.security = SECURITY_LEVEL, .start = 0, .total = 0};
|                                       ^~~~~~~~~~~~~~
|                                       SECURITY_LEVEL_MAX
```

---

The changes introduced by both commits were successfully tested both inside BitBake and as a standalone Bazel build.
