### PR TITLE
Remove trit-to-tryte conversion

### DIFF
--- a/examples/e01_hello_world.c
+++ b/examples/e01_hello_world.c
@@ -10,27 +10,14 @@ retcode_t get_iota_node_info(iota_client_service_t *iota_client_service, get_nod
     // Connect to the node
     ret = iota_client_get_node_info(iota_client_service, node_response);
 
-    // Define variables to determine whether trit conversion succeeds
-    trit_t trytes_out[NUM_TRYTES_HASH + 1];
-    size_t trits_count = 0;
     // If the node returned data, print it to the console
     if (ret == RC_OK) {
         printf("appName %s \n", node_response->app_name->data);
         printf("appVersion %s \n", node_response->app_version->data);
 
-        // Convert the returned trits to trytes
-        // For more information about trits and trytes, see the IOTA documentation portal: https://docs.iota.org/docs/getting-started/0.1/introduction/ternary
-        trits_count = flex_trits_to_trytes(trytes_out, NUM_TRYTES_HASH,
-                                        node_response->latest_milestone, NUM_TRITS_HASH,
-                                        NUM_TRITS_HASH);
-        if (trits_count == 0) {
-            printf("Failed to convert trits to trytes\n");
-            goto done;
-        }
-        // Empty this string: we don't need it anymore
-        trytes_out[NUM_TRYTES_HASH] = '\0';
-
-        printf("latestMilestone %s \n", trytes_out);
+        printf("latestMilestone ");
+    	flex_trit_print(node_response->latest_milestone, NUM_TRITS_HASH);
+    	printf("\n");
         printf("latestMilestoneIndex %u\n", (uint32_t) node_response->latest_milestone_index);
         printf("latestSolidSubtangleMilestoneIndex %u\n", (uint32_t)
         node_response->latest_solid_subtangle_milestone_index);


### PR DESCRIPTION
Updated the example to use the built-in function to print the latestMilestone instead of converting trits to trytes